### PR TITLE
Resolve -Wunused-parameter warning

### DIFF
--- a/src/eewl.h
+++ b/src/eewl.h
@@ -76,6 +76,8 @@ struct EEWL {
   // class constructor
   template <typename T> EEWL(T &data, int blk_num_, int start_addr_) {
 
+    (void)data;
+
     // allocate and init control vars
     blk_size = sizeof(T) + 1;
     blk_num = blk_num_;


### PR DESCRIPTION
A quick PR to remove an unused variable warning. Thank you for the library!

```
In file included from /home/renee/redacted.ino:18:0:
/home/renee/Arduino/libraries/EEWL/src/eewl.h: In instantiation of 'EEWL::EEWL(T&, int, int) [with T = application_state_t]':
/home/renee/redacted.ino:194:88:   required from here
/home/renee/Arduino/libraries/EEWL/src/eewl.h:77:33: warning: unused parameter 'data' [-Wunused-parameter]
   template <typename T> EEWL(T &data, int blk_num_, int start_addr_) {
                                 ^~~~
```